### PR TITLE
Update rust toolchain

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -5,12 +5,9 @@
 #![no_main]
 #![deny(warnings)]
 #![feature(panic_info_message)]
-#![feature(default_alloc_error_handler)]
-#![feature(naked_functions, asm_sym, asm_const)]
+#![feature(naked_functions, asm_const)]
 // MemorySet 处理相交的 VmArea 时需要
 #![feature(btree_drain_filter)]
-// used in file/device/link.rs
-#![feature(const_btree_new)]
 // test.rs 输入 argv 需要
 #![feature(drain_filter)]
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 profile = "minimal"
-channel = "nightly-2022-04-11"
+channel = "nightly-2023-03-07"
 components = ["rust-src", "llvm-tools-preview", "rustfmt", "clippy"]
 targets = ["riscv64imac-unknown-none-elf"]


### PR DESCRIPTION
Previous rust toolchain cannot build cargo-binutils properly. This patch updates rust toolchain to the latest nightly build and removes some stablized feature mark.