### PR TITLE
Make mmap ignore undefined prot and flags bits

### DIFF
--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -223,8 +223,8 @@ pub fn syscall(syscall_id: usize, args: [usize; 6]) -> isize {
         SyscallNo::MMAP => sys_mmap(
             args[0],
             args[1],
-            MMAPPROT::from_bits(args[2] as u32).unwrap(),
-            MMAPFlags::from_bits(args[3] as u32).unwrap(),
+            MMAPPROT::from_bits_truncate(args[2] as u32),
+            MMAPFlags::from_bits_truncate(args[3] as u32),
             args[4] as i32,
             args[5],
         ),


### PR DESCRIPTION
Currently, if mmap syscall contains a undefined prot or flags bit, the kernel will panic. Although man page doesn't define how to deal with undefined flag bits, I think a better way is to just ignore them just like what Linux does. We don't know whether some new APIs will be introduced in the future. And the kernel shouldn't panic just because this small problem.