### PR TITLE
Make clone ignore undefined bits of flags

### DIFF
--- a/kernel/src/syscall/flags.rs
+++ b/kernel/src/syscall/flags.rs
@@ -223,7 +223,7 @@ pub const SIG_SETMASK: i32 = 2;
 
 pub fn resolve_clone_flags_and_signal(flag: usize) -> (CloneFlags, SignalNo) {
     (
-        CloneFlags::from_bits(flag as u32 & (!0x3f)).unwrap(),
+        CloneFlags::from_bits_truncate(flag as u32 & (!0x3f)),
         SignalNo::try_from(flag as u8 & 0x3f).unwrap(),
     )
 }


### PR DESCRIPTION
Currently, maturin panics when flags of clone contains undefined bits. The kernel shouldn't panic just because of this small issue. Ignoring those undefined bits is fine.